### PR TITLE
Add script to visualize Cobaya chains

### DIFF
--- a/plot_chains.py
+++ b/plot_chains.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Visualise Cobaya MCMC chains using helper functions.
+
+This script loads chains produced by Cobaya and stored in ``yamls/chains``.
+It relies on the plotting utilities defined in ``notebooks/viewchains.py``
+to generate simple triangle plots of the parameters of interest.
+"""
+
+import argparse
+import os
+import numpy as np
+from getdist.mcsamples import loadMCSamples
+
+from notebooks.viewchains import add_S8x, get_bestFit_values, make_triangle_plot
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Plot a chain using getdist")
+    ap.add_argument("--chain_dir", default="yamls/chains", help="directory with chain files")
+    ap.add_argument("--file_root", default="my_pr4", help="prefix of the chain files")
+    ap.add_argument(
+        "--params", nargs="+", default=["OmM", "sigma8", "S8x"],
+        help="parameters to display in the triangle plot",
+    )
+    ap.add_argument("--output", "-o", help="output image filename")
+    args = ap.parse_args()
+
+    root = os.path.join(args.chain_dir, args.file_root)
+    chain = loadMCSamples(root)
+
+    param_names = [p.name for p in chain.getParamNames().names]
+    if "S8x" not in param_names:
+        add_S8x(chain)
+
+    maxima = None
+    try:
+        bf = get_bestFit_values(root)
+        maxima = np.array([[bf[p] for p in args.params]])
+    except Exception:
+        pass
+
+    make_triangle_plot(
+        [chain],
+        [args.file_root],
+        args.params,
+        filled=True,
+        save_path=args.output,
+        maxima=maxima,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `plot_chains.py` for plotting chains with helper functions from `notebooks/viewchains.py`

## Testing
- `pytest -q`
- `python plot_chains.py --output test.png`

------
https://chatgpt.com/codex/tasks/task_e_6847f5672c0c832799cf42bd5868ecb1