### PR TITLE
Add theory overlay for cross spectra and covariance heatmap

### DIFF
--- a/plot_cl_corr_heatmap.py
+++ b/plot_cl_corr_heatmap.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Display a correlation matrix heatmap for power spectra.
+
+Given a JSON file produced by the power-spectrum pipeline (for example
+``lrg_galaxy_auto.json`` or ``lrg_cross_pr4.json``), this script
+extracts the covariance matrix for a chosen pair of maps and displays
+its correlation matrix as a heatmap.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def load_json(path):
+    """Return ell values and covariance matrices from ``path``."""
+    with open(path) as f:
+        data = json.load(f)
+    ell = np.asarray(data.get("ell") or data.get("ells"))
+    covs = {
+        k[4:]: np.asarray(v) for k, v in data.items() if k.startswith("cov_")
+    }
+    return ell, covs
+
+
+def covariance_to_correlation(cov):
+    std = np.sqrt(np.diag(cov))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        corr = cov / std[:, None] / std[None, :]
+    corr[np.isnan(corr)] = 0
+    return corr
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Affiche une matrice de corrélation")
+    ap.add_argument("json", help="fichier JSON contenant les C_ell")
+    ap.add_argument("pair", help="nom du spectre, ex: PR4_LRGz1")
+    ap.add_argument("--output", "-o", default=None, help="image de sortie")
+    args = ap.parse_args()
+
+    ell, covs = load_json(args.json)
+    key = args.pair if args.pair.startswith("cov_") else args.pair
+    key = key.replace("cov_", "")
+    if key not in covs:
+        raise ValueError(f"Covariance for {key} not found in {args.json}")
+
+    corr = covariance_to_correlation(covs[key])
+
+    sns.set_context("talk")
+    fig, ax = plt.subplots(figsize=(6, 5))
+    sns.heatmap(
+        corr,
+        cmap="RdBu_r",
+        vmin=-1,
+        vmax=1,
+        center=0,
+        square=True,
+        cbar_kws={"label": "coefficient"},
+        ax=ax,
+    )
+    ax.set_title(f"Correlation matrix: {key}")
+    ax.set_xlabel(r"$\ell$")
+    ax.set_ylabel(r"$\ell$")
+    plt.tight_layout()
+
+    out = args.output or f"corr_{Path(args.json).stem}_{key}.png"
+    plt.savefig(out)
+    plt.close(fig)
+    print(f"→ {out}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/spectra/plot_coeffs_croisees.py
+++ b/spectra/plot_coeffs_croisees.py
@@ -1,14 +1,33 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Usage :
-    python plot_coeffs_croisees.py lrg_cross_pr4.json
-    python plot_coeffs_croisees.py lrg_cross_pr3.json
-    python plot_coeffs_croisees.py lrg_cross_pr3.json lrg_cross_pr4.json
+Plot the cross spectra :math:`C_{\ell}^{\kappa g}`.
+
+Several JSON files can be given.  If one of them contains the word
+``theory`` or ``fiducial`` in its file name, it is interpreted as the
+theoretical prediction and plotted as a line.  All the other files are
+considered data and are plotted with error bars.  A ratio data/theory
+panel is shown underneath each spectrum, similarly to
+``plot_coeffs_auto.py``.
+
+Examples
+--------
+```
+python plot_coeffs_croisees.py lrg_cross_pr4.json fiducial/theory_bandpowers.json
+python plot_coeffs_croisees.py lrg_cross_pr3.json lrg_cross_pr4.json
+```
 """
-import json, argparse, re, itertools, pathlib
+
+import json
+import argparse
+import re
+import itertools
+import pathlib
+
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+from scipy.interpolate import interp1d
 
 # ---------- STYLE ----------
 plt.rcParams.update({
@@ -20,76 +39,136 @@ COLORS   = ["#332288", "#88CCEE", "#44AA99", "#117733",
             "#999933", "#DDCC77", "#CC6677", "#882255"]
 MARKERS  = ["o", "s", "D", "^", "v", ">", "<", "P"]
 
+FULL_NAMES = {
+    "LRGz1": "LRG bin z1",
+    "LRGz2": "LRG bin z2",
+    "LRGz3": "LRG bin z3",
+    "LRGz4": "LRG bin z4",
+}
+
 # ---------- OUTILS ----------
 def load_json(fn):
-    """-> ell, {bin:cl}, {bin:cov}, TAG."""
+    """Return ``ell``, spectra and covariances for the file ``fn``."""
+
     with open(fn) as f:
         d = json.load(f)
+
     ell = np.asarray(d.get("ell") or d.get("ells"))
-    # trouve TAG et bins
+
     tag_pat = re.compile(r"cl_([^_]+)_(.+)")
     tag = next(tag_pat.match(k).group(1) for k in d if k.startswith("cl_"))
     bin_pat = re.compile(rf"cl_{re.escape(tag)}_(.+)")
     bins = sorted({bin_pat.match(k).group(1) for k in d if bin_pat.match(k)})
-    cls  = {b: np.asarray(d[f"cl_{tag}_{b}"]) for b in bins}
-    covs = {b: np.asarray(d[f"cov_{tag}_{b}_{tag}_{b}"]) for b in bins}
-    return ell, cls, covs, tag.upper(), bins
 
-def make_overview(ell, bundles, outfile):
-    """toutes les releases sur un seul axe."""
-    plt.figure(figsize=(6,4))
-    multi = len(bundles) > 1
-    for c,(tag,cls,covs,bins) in zip(itertools.cycle(COLORS), bundles):
-        for m,b in zip(MARKERS, bins):
-            err = np.sqrt(np.diag(covs[b]))
-            lab = f"{tag} {b}" if multi else b
-            plt.errorbar(ell, cls[b], yerr=err,
-                         fmt=m+"-", ms=4, lw=1, capsize=2,
-                         color=c if multi else None, label=lab)
-    plt.yscale("log"); plt.xlabel(r"$\ell$"); plt.ylabel(r"$C_\ell^{\kappa g}$")
-    plt.title("Spectres croisés κ×LRG"); plt.grid(ls=":")
-    plt.legend(frameon=False, ncol=2)
-    plt.tight_layout(); plt.savefig(outfile)
+    cls = {b: np.asarray(d[f"cl_{tag}_{b}"]) for b in bins}
+    covs = {
+        b: np.asarray(d.get(f"cov_{tag}_{b}_{tag}_{b}", np.zeros((len(ell), len(ell)))) )
+        for b in bins
+    }
 
-def make_panels(ell, bundles, outfile):
-    """un panel par bin, releases superposées."""
-    bins = bundles[0][3]                     # même liste pour tous
-    fig, axes = plt.subplots(2,2, figsize=(7,5), sharex=True, sharey=True)
-    axes = axes.ravel()
-    for ax,b in zip(axes, bins):
-        for c,(tag,cls,covs,_) in zip(COLORS, bundles):
-            m = MARKERS[list(bins).index(b)]
+    return pathlib.Path(fn).stem, ell, cls, covs, bins
+
+
+def classify_data(bundles):
+    """Separate data files and (optional) theory file."""
+
+    data = []
+    theory = None
+
+    for label, ell, cls, covs, bins in bundles:
+        if "theory" in label.lower() or "fiducial" in label.lower():
+            theory = (label, ell, cls)
+        else:
+            data.append((label, ell, cls, covs))
+
+    return data, theory
+
+
+def make_panels(bins, data_files, theory_file, output_prefix):
+    """Plot cross-spectra with optional theory overlay."""
+
+    fig = plt.figure(figsize=(12, 6))
+    gs = GridSpec(2, len(bins), height_ratios=[3, 1], hspace=0.05)
+
+    axes_top = [fig.add_subplot(gs[0, i]) for i in range(len(bins))]
+    axes_bot = [fig.add_subplot(gs[1, i], sharex=axes_top[i]) for i in range(len(bins))]
+
+    legend_handles = []
+    legend_labels = []
+
+    for i, b in enumerate(bins):
+        ax = axes_top[i]
+        ax_r = axes_bot[i]
+
+        # Theory line
+        if theory_file and f"cl_PR4_{b}" in theory_file[2]:
+            th_ell = theory_file[1]
+            th_spec = theory_file[2][f"cl_PR4_{b}"]
+            line, = ax.plot(th_ell, th_spec, 'k-', lw=2, alpha=0.7)
+            if i == 0:
+                legend_handles.append(line)
+                legend_labels.append("Théorie")
+
+        for (label, ell, cls, covs), color, marker in zip(data_files, itertools.cycle(COLORS), itertools.cycle(MARKERS)):
+            spec = cls[b]
             err = np.sqrt(np.diag(covs[b]))
-            ax.errorbar(ell, cls[b], yerr=err,
-                        fmt=m, ms=4, lw=1, capsize=2,
-                        color=c, label=tag)
-        ax.set_yscale("log"); ax.set_title(b.replace("LRG","LRG "))
-        ax.grid(ls=":")
-    axes[2].set_xlabel(r"$\ell$"); axes[3].set_xlabel(r"$\ell$")
-    axes[0].set_ylabel(r"$C_\ell$"); axes[2].set_ylabel(r"$C_\ell$")
-    # légende commune
-    handles, labels = axes[0].get_legend_handles_labels()
-    fig.legend(handles[:len(bundles)], labels[:len(bundles)],
-               frameon=False, loc="upper center", ncol=len(bundles))
-    plt.tight_layout(rect=[0,0,1,0.94]); plt.savefig(outfile)
+            eb = ax.errorbar(ell, spec, yerr=err, fmt=marker, ms=5, capsize=2,
+                             color=color, label=label)
+
+            if i == 0:
+                legend_handles.append(eb)
+                legend_labels.append(label)
+
+            if theory_file and f"cl_PR4_{b}" in theory_file[2]:
+                th_interp = interp1d(th_ell, th_spec, bounds_error=False,
+                                     fill_value=(th_spec[0], th_spec[-1]))
+                th_at_data = th_interp(ell)
+                ratio = spec / th_at_data
+                ratio_err = err / th_at_data
+                ax_r.errorbar(ell, ratio, yerr=ratio_err, fmt=marker, ms=5,
+                              capsize=2, color=color)
+
+        title = FULL_NAMES.get(b, b)
+        ax.set_title(title)
+        ax.set_yscale('log')
+        ax.set_xscale('log')
+        ax.grid(ls=':')
+
+        ax_r.axhline(1.0, color='k', ls='--', alpha=0.5)
+        ax_r.set_ylim(0.5, 1.5)
+        ax_r.set_xscale('log')
+        ax_r.set_xlabel(r"$\ell$")
+        ax_r.grid(ls=':')
+        if i == 0:
+            ax.set_ylabel(r"$C_\ell^{\kappa g}$")
+            ax_r.set_ylabel("Données/Th")
+
+        ax_r.set_xlim(30, 3000)
+
+    fig.legend(legend_handles, legend_labels,
+               loc='upper center', bbox_to_anchor=(0.5, 0.98),
+               ncol=len(legend_labels), frameon=False)
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_prefix + ".png")
+    fig.savefig(output_prefix + ".pdf")
+    print(f"→ {output_prefix}.pdf et {output_prefix}.png")
 
 # ---------- MAIN ----------
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("json", nargs="+", help="fichiers lrg_cross_*.json")
+    ap.add_argument("json", nargs="+", help="fichiers lrg_cross_*.json ou theory")
     ap.add_argument("--show", action="store_true")
+    ap.add_argument("--output", "-o", default="cross", help="préfixe de sortie")
     args = ap.parse_args()
 
-    bundles = []
-    for fn in args.json:
-        ell, cls, covs, tag, bins = load_json(fn)
-        bundles.append((tag, cls, covs, bins))
+    bundles = [load_json(fn) for fn in args.json]
 
-    suf = "_".join([b[0] for b in bundles])
-    make_overview(ell, bundles, f"{suf}_overview.png")
-    make_panels  (ell, bundles, f"{suf}_panels.png")
+    data_files, theory_file = classify_data(bundles)
+    bins = bundles[0][4]
 
-    if args.show: plt.show()
+    make_panels(bins, data_files, theory_file, args.output)
+
+    if args.show:
+        plt.show()
     else:
         plt.close("all")
-        print(f"→ {suf}_overview.png  &  {suf}_panels.png")


### PR DESCRIPTION
## Summary
- update `plot_coeffs_croisees.py` to overlay data with fiducial theory and add data/theory ratio subplots
- new script `plot_cl_corr_heatmap.py` to visualise correlation matrices of power spectra

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684fc84bf94c8327bcfcefeb78510b26