### PR TITLE
Add full correlation matrix option

### DIFF
--- a/plot_cl_corr_heatmap.py
+++ b/plot_cl_corr_heatmap.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
+from likelihoods.pack_data import get_cov
 
 
 def load_json(path):
@@ -27,6 +28,43 @@ def load_json(path):
     return ell, covs
 
 
+def load_merged_json(cross_path, auto_path):
+    """Return dictionary containing all covariance matrices from two files."""
+    ell1, cov1 = load_json(cross_path)
+    ell2, cov2 = load_json(auto_path)
+    if len(ell1) != len(ell2) or not np.allclose(ell1, ell2):
+        raise ValueError("Ell arrays do not match between input files")
+    data = {"ell": ell1}
+    for k, v in cov1.items():
+        data[f"cov_{k}"] = v
+    for k, v in cov2.items():
+        data[f"cov_{k}"] = v
+    return data
+
+
+def build_full_covariance(data, kap_name="PR4", gal_names=None):
+    """Concatenate all covariance sub-blocks into a single matrix."""
+    if gal_names is None:
+        gal_names = [f"LRGz{i}" for i in range(1, 5)]
+
+    ell = np.asarray(data.get("ell") or data.get("ells"))
+    nell = len(ell)
+
+    pairs = [(g, g) for g in gal_names] + [
+        (kap_name, g) for g in gal_names
+    ] + [(kap_name, kap_name)]
+
+    n = len(pairs)
+    cov = np.zeros((n * nell, n * nell))
+    for i, (a1, a2) in enumerate(pairs):
+        for j, (b1, b2) in enumerate(pairs):
+            cov_block = get_cov(data, a1, a2, b1, b2)
+            cov[i * nell : (i + 1) * nell, j * nell : (j + 1) * nell] = cov_block
+
+    labels = [f"{p[0]}_{p[1]}" for p in pairs]
+    return ell, cov, labels
+
+
 def covariance_to_correlation(cov):
     std = np.sqrt(np.diag(cov))
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -36,11 +74,46 @@ def covariance_to_correlation(cov):
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Affiche une matrice de corrélation")
-    ap.add_argument("json", help="fichier JSON contenant les C_ell")
-    ap.add_argument("pair", help="nom du spectre, ex: PR4_LRGz1")
+    ap = argparse.ArgumentParser(
+        description="Affiche une matrice de corrélation pour un spectre ou l'ensemble des observables"
+    )
+    ap.add_argument("json", nargs="?", help="fichier JSON contenant les C_ell")
+    ap.add_argument("pair", nargs="?", help="nom du spectre, ex: PR4_LRGz1")
+    ap.add_argument("--cross-json", default="spectra/lrg_cross_pr4.json", help="fichier de covariance croisée")
+    ap.add_argument("--auto-json", default="spectra/pr4_kappa_auto.json", help="fichier de covariance auto κκ")
+    ap.add_argument("--full", action="store_true", help="affiche la matrice complète")
     ap.add_argument("--output", "-o", default=None, help="image de sortie")
     args = ap.parse_args()
+
+    if args.full:
+        data = load_merged_json(args.cross_json, args.auto_json)
+        ell, cov, labels = build_full_covariance(data)
+        corr = covariance_to_correlation(cov)
+
+        sns.set_context("talk")
+        fig, ax = plt.subplots(figsize=(8, 6))
+        sns.heatmap(
+            corr,
+            cmap="RdBu_r",
+            vmin=-1,
+            vmax=1,
+            center=0,
+            square=True,
+            cbar_kws={"label": "coefficient"},
+            ax=ax,
+        )
+        ax.set_title("Correlation matrix: all spectra")
+        ax.set_xlabel("data vector index")
+        ax.set_ylabel("data vector index")
+        plt.tight_layout()
+        out = args.output or "corr_all_spectra.png"
+        plt.savefig(out)
+        plt.close(fig)
+        print(f"→ {out}")
+        return
+
+    if args.json is None or args.pair is None:
+        ap.error("json et pair requis sans --full")
 
     ell, covs = load_json(args.json)
     key = args.pair if args.pair.startswith("cov_") else args.pair


### PR DESCRIPTION
## Summary
- enhance `plot_cl_corr_heatmap.py` to build a full correlation matrix
- add CLI options for merged covariance files and full plotting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68502b873ec08327a1bb70d6eef998d3